### PR TITLE
Handle the first occurence of an error as urgent

### DIFF
--- a/src/sysmonitor/SystemMonitor.php
+++ b/src/sysmonitor/SystemMonitor.php
@@ -101,7 +101,10 @@ class SystemMonitor
         $count = $this->storage->count($sysEvt);
 
         // uplift severity..
-        if ($count >= 10 && $evt instanceof RequestExceptionEvent) {
+        if ($count === 1) {
+            // report the first occurence immediately, but don't report every single error
+            $sysEvt->severity = SystemEvent::SEVERITY_URGENT;
+        } elseif ($count >= 10 && $evt instanceof RequestExceptionEvent) {
             // .. based on frequency of the same failure
             $sysEvt->severity = SystemEvent::SEVERITY_URGENT;
         } elseif ($count >= 20 && $evt instanceof RequestStatsEvent) {

--- a/src/sysmonitor/SystemMonitor.php
+++ b/src/sysmonitor/SystemMonitor.php
@@ -101,7 +101,7 @@ class SystemMonitor
         $count = $this->storage->count($sysEvt);
 
         // uplift severity..
-        if ($count === 0) {
+        if ($count === 0 && $evt instanceof RequestExceptionEvent) {
             // report the first occurence immediately, but don't report every single error
             $sysEvt->severity = SystemEvent::SEVERITY_URGENT;
         } elseif ($count >= 10 && $evt instanceof RequestExceptionEvent) {

--- a/src/sysmonitor/SystemMonitor.php
+++ b/src/sysmonitor/SystemMonitor.php
@@ -101,7 +101,7 @@ class SystemMonitor
         $count = $this->storage->count($sysEvt);
 
         // uplift severity..
-        if ($count === 1) {
+        if ($count === 0) {
             // report the first occurence immediately, but don't report every single error
             $sysEvt->severity = SystemEvent::SEVERITY_URGENT;
         } elseif ($count >= 10 && $evt instanceof RequestExceptionEvent) {


### PR DESCRIPTION
that way rare but critical errors don't need to happen 10 times before we get the first report.
lets make sure the reporting backends at least get notified when a problem occurs the very first time.